### PR TITLE
Set the Sitemap priorities within the config.ini (SEO)

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -99,6 +99,16 @@ default.thumbnail = ""
 ; Enable view Counter, the options is "true" and "false". If set to "true", you can see the Counts in Admin page.
 views.counter = "true"
 
+; Sitemap priorities between "0.0" and "1.0". Set "false" to disable a sitemap for the given type. (See /sitemap.xml)
+sitemap.priority.base = "1.0"
+sitemap.priority.post = "0.5"
+sitemap.priority.static = "0.5"
+sitemap.priority.tag = "0.5"
+sitemap.priority.archiveDay = "0.5"
+sitemap.priority.archiveMonth = "0.5"
+sitemap.priority.archiveYear = "0.5"
+sitemap.priority.author = "0.5"
+
 ; Also install pre-release
 prerelease = false
 


### PR DESCRIPTION
Feature to change Sitemap priorities direct with the "config.ini" for
SEO. Additionally this commit adds the "lastmod" tag for posts.

- Set the Sitemap priorities for subtypes (Base, Post, Static, Tag, ...)
within the config.ini
- Values beween 1.0 and 0.0 or "false" to disable a subtype.
- Default priority is 0.5 as fallback. (see functions.php) The default
for "base" (Homepage) is 1.0.
- Disabled subtypes aren't available in the sitemap.xml (index).
- The sitemap for posts now contains the "lastmod" set the the post's
date.