### PR TITLE
404 pages rendered within layout

### DIFF
--- a/system/admin/views/layout.html.php
+++ b/system/admin/views/layout.html.php
@@ -4,7 +4,9 @@
     <?php echo head_contents() ?>
     <title><?php echo $title;?></title>
     <meta name="description" content="<?php echo $description; ?>"/>
-    <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php if($canonical): ?>
+        <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php endif; ?>
     <link href="<?php echo site_url() ?>themes/default/css/style.css" rel="stylesheet"/>
     <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
     <?php if (publisher()): ?>

--- a/system/htmly.php
+++ b/system/htmly.php
@@ -1301,13 +1301,19 @@ get('/search/:keyword', function ($keyword) {
 
     $posts = get_keyword($keyword, $page, $perpage);
 
-    $total = keyword_count($keyword);
-
-    if (empty($posts) || $page < 1) {
-        // a non-existing page
-        render('404-search', null, false);
+    if (!$posts || $page < 1) {
+        // a non-existing page or no search result
+        render('404-search', array(
+            'title' => 'Search results not found! - ' . blog_title(),
+            'description' => '',
+            'breadcrumb' => '<a href="' . site_url() . '">' . config('breadcrumb.home') . '</a> &#187; No search results',
+            'canonical' => site_url() . 'search/' . strtolower($keyword),
+            'bodyclass' => 'error-404-search',
+        ));
         die;
     }
+
+    $total = keyword_count($keyword);
 
     render('main', array(
         'title' => 'Search results for: ' . tag_i18n($keyword) . ' - ' . blog_title(),

--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -654,13 +654,7 @@ function get_keyword($keyword, $page, $perpage)
         }
     }
 
-    if (empty($tmp)) {
-        // a non-existing page
-        render('404-search', null, false);
-        die;
-    }
-
-    return $tmp = get_posts($tmp, $page, $perpage);
+    return ($tmp) ? get_posts($tmp, $page, $perpage) : [];
 }
 
 // Get related posts base on post tag.
@@ -1543,7 +1537,13 @@ EOF;
 function not_found()
 {
     header($_SERVER["SERVER_PROTOCOL"] . " 404 Not Found");
-    render('404', null, false);
+    render('404', array(
+        'title' => 'This page doesn\'t exist! - ' . blog_title(),
+        'description' => '',
+        'canonical' => false,
+        'breadcrumb' => '<a href="' . site_url() . '">' . config('breadcrumb.home') . '</a> &#187; 404 Not Found',
+        'bodyclass' => 'error-404',
+    ));
     die();
 }
 

--- a/themes/blog/404-search.html.php
+++ b/themes/blog/404-search.html.php
@@ -1,21 +1,16 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>Search results not found! - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/default/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-</head>
-<body>
-<div class="center message">
-    <h1>Search results not found!</h1>
-    <div class="search-404">
-        <?php echo search() ?>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<section class="inpage post section">
+    <div class="section-inner">
+        <div class="content">
+            <div class="item">
+                <h1 class="title">Search results not found!</h1>
+                <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
+                <div class="search-404">
+                    <?php echo search() ?>
+                </div>
+            </div>
+        </div>
     </div>
-    <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
-</div>
-</body>
-</html>
+</section>

--- a/themes/blog/404.html.php
+++ b/themes/blog/404.html.php
@@ -1,18 +1,14 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>404 Not Found - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/default/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-</head>
-<body>
-<div class="center message">
-    <h1>This page doesn't exist!</h1>
-    <p>Would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
-</div>
-</body>
-</html>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<section class="inpage post section">
+    <div class="section-inner">
+        <div class="content">
+            <div class="item">
+                <h1 class="title">This page doesn't exist!</h1>
+                <p>Please search to find what you're looking for or visit our <a href="<?php echo site_url() ?>">homepage</a> instead.</p>
+                <?php echo search() ?>
+            </div>
+        </div>
+    </div>
+</section>

--- a/themes/blog/layout.html.php
+++ b/themes/blog/layout.html.php
@@ -6,7 +6,9 @@
     <?php echo head_contents();?>
     <title><?php echo $title;?></title>
     <meta name="description" content="<?php echo $description; ?>"/>
-    <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php if($canonical): ?>
+        <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php endif; ?>
     <?php if (publisher()): ?>
     <link href="<?php echo publisher() ?>" rel="publisher" /><?php endif; ?>    
     <link href="//fonts.googleapis.com/css?family=Lato:300,400,300italic,400italic" rel="stylesheet" type="text/css">

--- a/themes/clean/404-search.html.php
+++ b/themes/clean/404-search.html.php
@@ -1,21 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>Search results not found! - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/clean/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans+Condensed:700&subset=latin,cyrillic-ext" rel="stylesheet"/>
-</head>
-<body>
-<div class="center message">
-    <h1>Search results not found!</h1>
-    <div class="search">
-        <?php echo search() ?>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<div class="post">
+    <div class="main">
+        <h1 class="title-post">Search results not found!</h1>
+        <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
+        <div class="search-404">
+            <?php echo search() ?>
+        </div>
     </div>
-    <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
 </div>
-</body>
-</html>

--- a/themes/clean/404.html.php
+++ b/themes/clean/404.html.php
@@ -1,18 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>404 Not Found - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/clean/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans+Condensed:700&subset=latin,cyrillic-ext" rel="stylesheet"/>
-</head>
-<body>
-<div class="center message">
-    <h1>This page doesn't exist!</h1>
-    <p>Would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<div class="post">
+    <div class="main">
+        <h1 class="title-post">This page doesn't exist!</h1>
+        <p>Please search to find what you're looking for or visit our <a href="<?php echo site_url() ?>">homepage</a> instead.</p>
+        <?php echo search() ?>
+    </div>
 </div>
-</body>
-</html>

--- a/themes/clean/layout.html.php
+++ b/themes/clean/layout.html.php
@@ -4,7 +4,9 @@
     <?php echo head_contents() ?>
     <title><?php echo $title;?></title>
     <meta name="description" content="<?php echo $description; ?>"/>
-    <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php if($canonical): ?>
+        <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php endif; ?>
     <link href="<?php echo site_url() ?>themes/clean/css/style.css" rel="stylesheet"/>
     <link href="//fonts.googleapis.com/css?family=Open+Sans+Condensed:700&subset=latin,cyrillic-ext" rel="stylesheet"/>
     <?php if (publisher()): ?>

--- a/themes/default/404-search.html.php
+++ b/themes/default/404-search.html.php
@@ -1,21 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>Search results not found! - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/default/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-</head>
-<body>
-<div class="center message">
-    <h1>Search results not found!</h1>
-    <div class="search-404">
-        <?php echo search() ?>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<div class="post">
+    <div class="main">
+        <h1 class="title-post">Search results not found!</h1>
+        <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
+        <div class="search-404">
+            <?php echo search() ?>
+        </div>
     </div>
-    <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
 </div>
-</body>
-</html>

--- a/themes/default/404.html.php
+++ b/themes/default/404.html.php
@@ -1,18 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>404 Not Found - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/default/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-</head>
-<body>
-<div class="center message">
-    <h1>This page doesn't exist!</h1>
-    <p>Would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<div class="post">
+    <div class="main">
+        <h1 class="title-post">This page doesn't exist!</h1>
+        <p>Please search to find what you're looking for or visit our <a href="<?php echo site_url() ?>">homepage</a> instead.</p>
+        <?php echo search() ?>
+    </div>
 </div>
-</body>
-</html>

--- a/themes/default/css/style.css
+++ b/themes/default/css/style.css
@@ -414,6 +414,11 @@ table.post-list td a {
     float: right;
 }
 
+.error-404 .post #search-form,
+.error-404-search .post #search-form {
+    float: none;
+}
+
 .search-input {
     margin: 0;
     padding: 4px 15px;
@@ -519,7 +524,7 @@ h1.title-post a:hover, h2.title-index a:hover {
     padding-top: 0;
 }
 
-.infront .first, .inpost .post, .intag .first, .inarchive .first, .insearch .first {
+.infront .first, .inpost .post, .intag .first, .inarchive .first, .insearch .first, .error-404 .post, .error-404-search .post {
     padding-top: 0;
 }
 

--- a/themes/default/layout.html.php
+++ b/themes/default/layout.html.php
@@ -4,7 +4,9 @@
     <?php echo head_contents() ?>
     <title><?php echo $title;?></title>
     <meta name="description" content="<?php echo $description; ?>"/>
-    <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php if($canonical): ?>
+        <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php endif; ?>
     <link href="<?php echo site_url() ?>themes/default/css/style.css" rel="stylesheet"/>
     <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
     <?php if (publisher()): ?>

--- a/themes/logs/404-search.html.php
+++ b/themes/logs/404-search.html.php
@@ -1,21 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>Search results not found! - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/logs/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-</head>
-<body>
-<div class="center message">
-    <h1>Search results not found!</h1>
-    <div class="search-404">
-        <?php echo search() ?>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<div class="post">
+    <div class="main">
+        <h1 class="title-post">Search results not found!</h1>
+        <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
+        <div class="search-404">
+            <?php echo search() ?>
+        </div>
     </div>
-    <p>Please search again, or would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
 </div>
-</body>
-</html>

--- a/themes/logs/404.html.php
+++ b/themes/logs/404.html.php
@@ -1,18 +1,10 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <link href='<?php echo site_url() ?>favicon.ico' rel='icon' type='image/x-icon'/>
-    <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" user-scalable="no"/>
-    <title>404 Not Found - <?php echo blog_title() ?></title>
-    <link href="<?php echo site_url() ?>themes/logs/css/style.css" rel="stylesheet"/>
-    <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-</head>
-<body>
-<div class="center message">
-    <h1>This page doesn't exist!</h1>
-    <p>Would you like to try our <a href="<?php echo site_url() ?>">homepage</a> instead?</p>
+<?php if (!empty($breadcrumb)): ?>
+    <div class="breadcrumb"><?php echo $breadcrumb ?></div>
+<?php endif; ?>
+<div class="post">
+    <div class="main">
+        <h1 class="title-post">This page doesn't exist!</h1>
+        <p>Please search to find what you're looking for or visit our <a href="<?php echo site_url() ?>">homepage</a> instead.</p>
+        <?php echo search() ?>
+    </div>
 </div>
-</body>
-</html>

--- a/themes/logs/css/style.css
+++ b/themes/logs/css/style.css
@@ -332,6 +332,10 @@ ul li, ol li {
 #search-form {
     float: right;
 }
+.error-404 .post #search-form,
+.error-404-search .post #search-form {
+    float: none;
+}
 
 .search-input {
     border: 1px solid #E5E5E5;

--- a/themes/logs/layout.html.php
+++ b/themes/logs/layout.html.php
@@ -4,7 +4,9 @@
     <?php echo head_contents() ?>
     <title><?php echo $title;?></title>
     <meta name="description" content="<?php echo $description; ?>"/>
-    <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php if($canonical): ?>
+        <link rel="canonical" href="<?php echo $canonical; ?>" />
+    <?php endif; ?>
     <link href="<?php echo site_url() ?>themes/logs/css/style.css" rel="stylesheet"/>
     <link href="//fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
     <?php if (publisher()): ?>


### PR DESCRIPTION
Before this pull request, the 404 and 404-search templates where handled
as full HTML pages without the page context (layout).

With this pull request both pages are rendered inside the selected
themes layout. Additionally the 404 template now contains the "search
form" and the homepage link.

All Themes are already updated with the above changes.