### PR TITLE
Added step=1 to the time input to add seconds selection.

### DIFF
--- a/system/admin/views/edit-content.html.php
+++ b/system/admin/views/edit-content.html.php
@@ -95,7 +95,7 @@ if (config('permalink.type') == 'post') {
         <input type="date" name="date" class="text" value="<?php echo date('Y-m-d', $postdate); ?>">
         <br>
         Hour, Minute, Second<br>
-        <input type="time" name="time" class="text" value="<?php echo $time->format('H:i:s'); ?>">
+        <input step="1" type="time" name="time" class="text" value="<?php echo $time->format('H:i:s'); ?>">
         <br><br>
         Meta Description (optional)<br>
         <textarea name="description" rows="3" cols="20"><?php if (isset($p->description)) { echo $p->description; } else { echo $olddescription;} ?></textarea>


### PR DESCRIPTION
Without the step modifier users on (at least) Chrome mobile couldn't edit blogs because the seconds were missing
(hh:mm while hh:mm:ss was expected)

This is my first commit, hope it worked :)