### PR TITLE
bug fix: disqus always want absolute url, so a relative url in config.site.url breaks disqus. 

### DIFF
--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -1859,7 +1859,7 @@ function disqus($title = null, $url = null)
     $script = <<<EOF
     <script type="text/javascript">
         var getAbsolutePath = function(href) {
-            var link = document.createElement('__dummy_get_absolute_path');
+            var link = document.createElement('a');
             link.href = href;
             return link.href;
         };

--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -1858,9 +1858,14 @@ function disqus($title = null, $url = null)
     $disqus = config('disqus.shortname');
     $script = <<<EOF
     <script type="text/javascript">
+        var getAbsolutePath = function(href) {
+            var link = document.createElement('__dummy_get_absolute_path');
+            link.href = href;
+            return link.href;
+        };
         var disqus_shortname = '{$disqus}';
         var disqus_title = '{$title}';
-        var disqus_url = '{$url}';
+        var disqus_url = getAbsolutePath('{$url}');
         (function () {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
             dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';


### PR DESCRIPTION
I have to host my blog on multiple domain, `recolic.net` for the Internet, and `recolic.cc` for china LAN (because `recolic.net` got attacked by China government). Then a relative url in config.site.url breaks disqus: 

```
site.url = '/blog/';
```

The reason is that, disqus always want absolute path, instead of relative path. 

![](https://recolic.net/res/github-issue-htmly.png)