### PR TITLE
Fix find_post bug

### DIFF
--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -386,7 +386,7 @@ function find_post($year, $month, $name)
 
     foreach ($posts as $index => $v) {
         $arr = explode('_', $v['basename']);
-        if (strpos($arr[0], "$year-$month") !== false && strtolower($arr[2]) === strtolower($name . '.md') || strtolower($arr[2]) === strtolower($name . '.md')) {
+        if ((strpos($arr[0], "$year-$month") !== false && strtolower($arr[2]) === strtolower($name . '.md')) || ($year === NULL && strtolower($arr[2]) === strtolower($name . '.md'))) {
 
             // Use the get_posts method to return
             // a properly parsed object


### PR DESCRIPTION
If there was two blog entries with the same permalink but different dates, `find_post` always returned the latest one and ignored year/month. Fixed by checking that `$year` is actually set to NULL, which is the case if you use the post/title permalink type.