### PR TITLE
replace broken .text() in jquery in firefox. Console to show exception

### DIFF
--- a/system/admin/editor/js/jquery.ajaxfileupload.js
+++ b/system/admin/editor/js/jquery.ajaxfileupload.js
@@ -107,11 +107,12 @@
           //  and clean up after ourselves. 
           */
           var handleResponse = function(loadedFrame, element) {
-            var response, responseStr = $(loadedFrame).contents().text();
+            var response, responseStr = $(loadedFrame).contents()[0].body.textContent;
             try {
               //response = $.parseJSON($.trim(responseStr));
               response = JSON.parse(responseStr);
             } catch(e) {
+              console.error(e);
               response = responseStr;
             }
 


### PR DESCRIPTION
Discussed in issue #442 442. The `.text()` doesn't work properly in Firefox for some reason, here is a workaround. Tested in Chrome and IE as well.