### PR TITLE
Quick Cookie Improvement

### DIFF
--- a/install.php
+++ b/install.php
@@ -222,7 +222,7 @@ if(from($_SERVER,'QUERY_STRING') == "rewriteRule.html")
     echo "YES!";
     die();
 }
-
+session_set_cookie_params(['samesite' => 'Strict']);
 session_start();
 new Settings;
 

--- a/system/admin/admin.php
+++ b/system/admin/admin.php
@@ -53,6 +53,7 @@ function session($user, $pass)
 
     if ($user_enc == "password_hash") {
         if (password_verify($pass, $user_pass)) {
+            if (session_status() == PHP_SESSION_NONE) session_start();
             if (password_needs_rehash($user_pass, PASSWORD_DEFAULT)) {
                 update_user($user, $pass, $user_role);
             }
@@ -62,6 +63,7 @@ function session($user, $pass)
             return $str = '<div class="error-message"><ul><li class="alert alert-danger">ERROR: Invalid username or password.</li></li></div>';
         }
     } else if (old_password_verify($pass, $user_enc, $user_pass)) {
+        if (session_status() == PHP_SESSION_NONE) session_start();
         update_user($user, $pass, $user_role);
         $_SESSION[config("site.url")]['user'] = $user;
         header('location: admin');

--- a/system/htmly.php
+++ b/system/htmly.php
@@ -2648,6 +2648,7 @@ get('/:static', function ($static) {
         }
         die;
     } elseif ($static === 'login') {
+        if (session_status() == PHP_SESSION_NONE) session_start();
         config('views.root', 'system/admin/views');
         render('login', array(
             'title' => 'Login - ' . blog_title(),

--- a/system/includes/session.php
+++ b/system/includes/session.php
@@ -1,9 +1,10 @@
 <?php
-
-session_start();
+if (isset($_COOKIE['PHPSESSID']))
+    session_start();
 
 function login()
 {
+    if (session_status() == PHP_SESSION_NONE) return false;
     if (isset($_SESSION[config("site.url")]['user']) && !empty($_SESSION[config("site.url")]['user'])) {
         return true;
     } else {

--- a/system/includes/session.php
+++ b/system/includes/session.php
@@ -1,4 +1,5 @@
 <?php
+session_set_cookie_params(['samesite' => 'Strict']);
 if (isset($_COOKIE['PHPSESSID']))
     session_start();
 


### PR DESCRIPTION
Accomplishes two things:
 - no PHPSESSID cookie set for casual readers (don't access the login page)
 - sets 'samesite' cookie attribute to 'strict' for csrf reasons and removes warning in console

I'm not sure what needs to be tested in this case, but logging in and forcing a logout via deleting the cookie works correctly.

I think this might be all that is needed to solve #438 

Also related: #429 