### PR TITLE
backup handling tweak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /content/*
 /config/config.ini
 /config/users/*.ini
+/backup

--- a/system/admin/views/backup.html.php
+++ b/system/admin/views/backup.html.php
@@ -3,7 +3,7 @@
 if (login()) {
     if (isset($_GET['file'])) {
         $file = _h($_GET['file']);
-
+        $file = preg_replace('/\/|\\\\/','0',$file);
         if (!empty($file)) {
             unlink("backup/$file");
         }


### PR DESCRIPTION
* removing any slashes should be a quick fix to keep deleting backups within the folder only. (#462)
* git can ignore the backup/ folder