### PR TITLE
Searching in the content of posts

### DIFF
--- a/system/admin/editor/js/Markdown.Editor.js
+++ b/system/admin/editor/js/Markdown.Editor.js
@@ -24,7 +24,7 @@
         italic: "Emphasis <em> Ctrl+I",
         italicexample: "emphasized text",
 		
-        strikethrough: "Strikethrough <s> Ctrl+X",
+        strikethrough: "Strikethrough <s>",
         strikethroughexample: "strikethrough text",
 
         link: "Hyperlink <a> Ctrl+L",
@@ -54,8 +54,8 @@
 		
         table: "Table - Ctrl+J",
 
-        undo: "Undo - Ctrl+Z",
-        redo: "Redo - Ctrl+Y",
+        undo: "Undo",
+        redo: "Redo",
         redomac: "Redo - Ctrl+Shift+Z",
 
         help: "Markdown Editing Help"

--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -200,7 +200,7 @@ function rebuilt_cache($type)
         if (is_array($tmp)) {
             foreach ($tmp as $file) {
                 if(strpos($file, '/draft/') === false) {
-                    $posts_cache_sorted[] = pathinfo($file);
+                    $posts_cache_sorted[] = array_merge(pathinfo($file), ['content' => preg_replace('/\s+/', '', (file_get_contents($file)))])
                 }
             }
         }
@@ -967,7 +967,7 @@ function get_keyword($keyword, $page, $perpage)
 
     foreach ($posts as $index => $v) {
         $arr = explode('_', $v['basename']);
-        $filter = $arr[1] . ' ' . $arr[2];
+        $filter = $arr[1] . ' ' . $arr[2] . ' ' . $v['content'];
         foreach ($words as $word) {
             if (stripos($filter, $word) !== false) {
                 if (!in_array($v, $tmp)) {

--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -1158,7 +1158,7 @@ function keyword_count($keyword)
 
     foreach ($posts as $index => $v) {
         $arr = explode('_', $v['basename']);
-        $filter = $arr[1] . ' ' . $arr[2];
+        $filter = $arr[1] . ' ' . $arr[2] . ' ' . $v['content'];
         foreach ($words as $word) {
             if (stripos($filter, $word) !== false) {
                 $tmp[] = $v;

--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -200,7 +200,7 @@ function rebuilt_cache($type)
         if (is_array($tmp)) {
             foreach ($tmp as $file) {
                 if(strpos($file, '/draft/') === false) {
-                    $posts_cache_sorted[] = array_merge(pathinfo($file), ['content' => preg_replace('/\s+/', '', (file_get_contents($file)))])
+                    $posts_cache_sorted[] = array_merge(pathinfo($file), ['content' => preg_replace('/\s+/', '', (file_get_contents($file)))]);
                 }
             }
         }


### PR DESCRIPTION
I added the content of the posts to the `index-sorted.txt` file. The content of multiple files is read when creating the cache in function `rebuilt_cache`

```
$posts_cache_sorted[] = array_merge(pathinfo($file), ['content' => preg_replace('/\s+/', '', (file_get_contents($file)))]);
```
And I added content to the search function `get_keyword`:

```
 $filter = $arr[1] . ' ' . $arr[2] . ' ' . $v['content'];
```

