### PR TITLE
Adjusted doStrikethrough preg_split

### DIFF
--- a/system/vendor/michelf/php-markdown/Michelf/MarkdownExtra.php
+++ b/system/vendor/michelf/php-markdown/Michelf/MarkdownExtra.php
@@ -1898,7 +1898,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		#    in:  text ~~deleted~~ from doc
 		#    out: text <del>deleted</del> from doc
 		#
-			$parts = preg_split('/(?<![~])(~~)(?![~])/', $text, 0, PREG_SPLIT_DELIM_CAPTURE);
+			$parts = preg_split('/(?<![~])(~~)(?![~])/', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
 			
 			//don't bother if nothing to do...
 			if(count($parts) <= 1)

--- a/system/vendor/michelf/php-markdown/Michelf/MarkdownExtra.php
+++ b/system/vendor/michelf/php-markdown/Michelf/MarkdownExtra.php
@@ -1898,7 +1898,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		#    in:  text ~~deleted~~ from doc
 		#    out: text <del>deleted</del> from doc
 		#
-			$parts = preg_split('/(?<![~])(~~)(?![~])/', $text, null, PREG_SPLIT_DELIM_CAPTURE);
+			$parts = preg_split('/(?<![~])(~~)(?![~])/', $text, 0, PREG_SPLIT_DELIM_CAPTURE);
 			
 			//don't bother if nothing to do...
 			if(count($parts) <= 1)


### PR DESCRIPTION
[21-Jun-2022 10:10:04 America/Denver] PHP Deprecated:  preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in C:\Server\html\system\vendor\michelf\php-markdown\Michelf\MarkdownExtra.php on line 1901

In PHP 8.1, preg_split handling null was deprecated. I changed null to 0 to resolve the php_error.

