### PR TITLE
Add enclosure image on RSS field

### DIFF
--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -2741,6 +2741,10 @@ function generate_rss($posts, $data = null)
                 ->description($body)
                 ->url($p->url)
                 ->appendTo($channel);
+                
+            if ($p->image !== null) {
+                $item->enclosure($p->image, 0, "image/" . end(explode('.', $p->image)));
+            }
         }
     }
 


### PR DESCRIPTION
I added the enclosure element on RSS fields. When a blog post have an image, we set the enclosure tag with his URL and his mime type.

The enclosure tag is used to attach multimedia content in an RSS feed.
I use it on my website to display blog posts images on the homepage, which request the RSS feed of my blog.