### PR TITLE
Security Fix

### DIFF
--- a/system/admin/admin.php
+++ b/system/admin/admin.php
@@ -903,8 +903,25 @@ function delete_post($file, $destination)
     $role = user('role', $user);
     $arr = explode('/', $file);
     
-    if ($arr[0] !== 'content')
+    // realpath resolves all traversal operations like ../
+    $realFilePath = realpath($file);
+
+    // realpath returns an empty string if the file does not exist
+    if ($realFilePath == '') {
         return;
+    }
+
+    // get the current project working directory
+    $cwd = getcwd();
+
+    // content directory relative to the current project working directory
+    $contentDir = $cwd . '\content';
+
+    // if the file path does not start with $contentDir, it means its accessing
+    // files in folders other than content
+    if (strpos($realFilePath, $contentDir) !== 0) {
+        return;
+    }
 
     // Get cache file
     $info = pathinfo($file);
@@ -937,8 +954,25 @@ function delete_page($file, $destination)
     $role = user('role', $user);
     $arr = explode('/', $file);
     
-    if ($arr[0] !== 'content')
+    // realpath resolves all traversal operations like ../
+    $realFilePath = realpath($file);
+
+    // realpath returns an empty string if the file does not exist
+    if ($realFilePath == '') {
         return;
+    }
+
+    // get the current project working directory
+    $cwd = getcwd();
+
+    // content directory relative to the current project working directory
+    $contentDir = $cwd . '\content';
+
+    // if the file path does not start with $contentDir, it means its accessing
+    // files in folders other than content
+    if (strpos($realFilePath, $contentDir) !== 0) {
+        return;
+    }
 
     if (!empty($menu)) {
         foreach (glob('cache/page/*.cache', GLOB_NOSORT) as $file) {


### PR DESCRIPTION
The fix in the commit https://github.com/danpros/htmly/commit/8f5a3a379996fe57e91777e678e521c7df6cbb70 is insufficient to prevent path traversal, as the attacker can still use payloads such as `content/../index.php` to bypass the check.

This PR uses `realpath` to resolve all path traversing operations to give the final path.

For example `/var/html/content/../index.php` becomes `/var/html/index.php`

It then creates a variable `contentDir` which is the fully qualified path for the content folder

e.g. `/var/html/content/`

When a user deletes a file, it checks if the absolute path of the file starts with `contentDir` (`/var/html/content/`). If it does not, it means that the file does not exist in `/var/html/content/`, and the operation is denied.