### PR TITLE
Replace RSS description value with Meta Description instead of Body

### DIFF
--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -3010,9 +3010,9 @@ function generate_rss($posts, $data = null)
         foreach ($posts as $p) {
             $img = get_image($p->body);
             if (!empty($rssLength)) {
-                $body = shorten($p->body, $rssLength);
+                $description = shorten($p->description, $rssLength);
             } else {
-                $body = $p->body;
+                $description = $p->description;
             }
 
             $item = new Item();
@@ -3021,7 +3021,7 @@ function generate_rss($posts, $data = null)
             $item
                 ->title($p->title)
                 ->pubDate($p->date)
-                ->description($body)
+                ->description($description)
                 ->url($p->url)
                 ->appendTo($channel);
 


### PR DESCRIPTION
The Meta Description of a post makes more sense for the RSS feed since it's either a user generated description of the post or automatically pulled from the post body. A user can leave the Meta Description blank to use the post body for the RSS feed (which is basically the current RSS method).