### PR TITLE
Update get_pagination() - see #800

### DIFF
--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -2197,13 +2197,17 @@ function get_pagination($totalitems, $page = 1, $perpage = 10, $adjacents = 1, $
         We're actually saving the code to a variable in case we want to draw it more than once.
     */
     $pagination = '';
-    if($lastpage > 1)
+    $curpage = strtok($_SERVER["REQUEST_URI"], '?');
+    
+	if($lastpage > 1)
     {
         $pagination .= '<ul class="pagination">';
 
         //newer button
-        if ($page > 1)
+        if ($page > 2)
             $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $prev .'">« '. i18n('Newer') .'</a></li>';
+		else if ($page == 2)
+			$pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage .'">« '. i18n('Newer') .'</a></li>';			
         else
             $pagination .= '<li class="page-item disabled"><span class="page-link">« '. i18n('Newer') . '</span></li>';
 
@@ -2212,10 +2216,12 @@ function get_pagination($totalitems, $page = 1, $perpage = 10, $adjacents = 1, $
         {
             for ($counter = 1; $counter <= $lastpage; $counter++)
             {
-                if ($counter == $page)
+				if ($counter == 1 && $counter !== $page) // link 1st pagination page to parent page instead of ?page=1 for SEO
+					$pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage .'">1</a></li>';
+                else if ($counter == $page)
                     $pagination .= '<li class="page-item active"><span class="page-link">'. $counter.'</span></li>';
                 else
-                    $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $counter .'">'. $counter .'</a></li>';
+                    $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $counter .'">'. $counter .'</a></li>';
             }
         }
         elseif($lastpage >= 7 + ($adjacents * 2))    //enough pages to hide some
@@ -2225,19 +2231,21 @@ function get_pagination($totalitems, $page = 1, $perpage = 10, $adjacents = 1, $
             {
                 for ($counter = 1; $counter < 4 + ($adjacents * 2); $counter++)
                 {
-                    if ($counter == $page)
+					if ($counter == 1) // link 1st pagination page to parent page instead of ?page=1 for SEO
+						$pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage .'">1</a></li>';
+                    else if ($counter == $page)
                         $pagination .= '<li class="page-item active"><span class="page-link">'. $counter .'</span></li>';
                     else
-                        $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $counter .'">'. $counter .'</a></li>';
+                        $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $counter .'">'. $counter .'</a></li>';
                 }
                 $pagination .= '<li class="page-item disabled"><span class="page-link">...</span></li>';
-                $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $lpm1 .'">'. $lpm1 .'</a></li>';
-                $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $lastpage .'">'. $lastpage .'</a></li>';
+                $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $lpm1 .'">'. $lpm1 .'</a></li>';
+                $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $lastpage .'">'. $lastpage .'</a></li>';
             }
             //in middle; hide some front and some back
             elseif($lastpage - ($adjacents * 2) > $page && $page > ($adjacents * 2))
             {
-                $pagination .= '<li class="page-item"><a class="page-link" href="' . $pagestring .'1">1</a></li>';
+                $pagination .= '<li class="page-item"><a class="page-link" href="' . $curpage .'">1</a></li>';
                 $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring .'2">2</a></li>';
                 $pagination .= '<li class="page-item disabled"><span class="page-link">...</span></li>';
                 for ($counter = $page - $adjacents; $counter <= $page + $adjacents; $counter++)
@@ -2245,16 +2253,16 @@ function get_pagination($totalitems, $page = 1, $perpage = 10, $adjacents = 1, $
                     if ($counter == $page)
                         $pagination .= '<li class="page-item active"><span class="page-link">'. $counter .'</span></li>';
                     else
-                        $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $counter .'">'. $counter .'</a></li>';
+                        $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $counter .'">'. $counter .'</a></li>';
                 }
                 $pagination .= '<li class="page-item disabled"><span class="page-link">...</span></li>';
-                $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $lpm1 .'">'. $lpm1 .'</a></li>';
-                $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $lastpage . '">'. $lastpage .'</a></li>';
+                $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $lpm1 .'">'. $lpm1 .'</a></li>';
+                $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $lastpage . '">'. $lastpage .'</a></li>';
             }
             //close to end; only hide early pages
             else
             {
-                $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring .'1">1</a></li>';
+                $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage .'">1</a></li>';
                 $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring .'2">2</a></li>';
                 $pagination .= '<li class="page-item disabled"><span class="page-link">...</span></li>';
                 for ($counter = $lastpage - (1 + ($adjacents * 3)); $counter <= $lastpage; $counter++)
@@ -2262,14 +2270,14 @@ function get_pagination($totalitems, $page = 1, $perpage = 10, $adjacents = 1, $
                     if ($counter == $page)
                         $pagination .= '<li class="page-item active"><span class="page-link">'. $counter .'</span></li>';
                     else
-                        $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $counter .'">'. $counter .'</a></li>';
+                        $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $counter .'">'. $counter .'</a></li>';
                 }
             }
         }
 
         //older button
         if ($page < $counter - 1)
-            $pagination .= '<li class="page-item"><a class="page-link" href="'. $pagestring . $next .'">'. i18n('Older') .' »</a></li>';
+            $pagination .= '<li class="page-item"><a class="page-link" href="'. $curpage . $pagestring . $next .'">'. i18n('Older') .' »</a></li>';
         else
             $pagination .= '<li class="page-item disabled"><span class="page-link">'. i18n('Older') .' »</span></li>';
         $pagination .= '</ul>';


### PR DESCRIPTION
Since generation of canonical metatags were updated for paginated pages - which was a good change towards SEO - another "problem" arised with "_Alternate page with proper canonical tag_". It basically relates to the 1st paginated page with "?page=1" in url. Although it contains proper canonical tag indicating main page with blog posts. I wanted to:
1. get rid of this duplicated page in pagination so that all other pages point to the main blog page instead of page=1, allowing me to also get rid of above mentioned notification in g.search console
2. generate proper relative urls for paginated pages. All html hrefs contain "?page=N" no matter what page is used for blog posts listing. Either it is index page or any other declared page like /blog

Since I use /blog page for posts list I achieved proper href values both on index pages and decalred page, so I'm sharing the changes. This commit affects only pagination generated using `<?php echo $pagination['html'];?>` which is used afaik only in "blog" theme. All other themes show only previous/next buttons to navigate through posts list, thus additional changes would have to be made per theme basis which is out of scope in this commit.

As a suggestion it would be nice to achieve friendly urls in pagination but I couldn't find out how url routing is solved in htmly.