### PR TITLE
restrict Search $keyword ≥ three-character strings

### DIFF
--- a/system/includes/functions.php
+++ b/system/includes/functions.php
@@ -1319,35 +1319,39 @@ function get_frontpage()
 // Return search page.
 function get_keyword($keyword, $page, $perpage)
 {
-    $posts = get_blog_posts();
 
-    $tmp = array();
+	if (strlen($keyword) >= 3) { // three-character or more search, only
 
-    foreach ($posts as $index => $v) {
+		$posts = get_blog_posts();
 
-		$filepath = $v['dirname'] . '/' . $v['basename'];
+		$tmp = array();
 
-		$findRxWhole = '\b' . preg_quote($keyword, '~') . '\b'; // Add word boundaries (find whole-words only)
+		foreach ($posts as $index => $v) {
 
-		$findRx = "~{$findRxWhole}~iu"; // Case-insensitive and UTF-8 mode
+			$filepath = $v['dirname'] . '/' . $v['basename'];
 
-		$lines = file($filepath);
+			$findRxWhole = '\b' . preg_quote($keyword, '~') . '\b'; // Add word boundaries (find whole-words only)
 
-        foreach ($lines as $line) {
-			if (preg_match ($findRx, $line)) {
-                if (!in_array($v, $tmp)) {
-                    $tmp[] = $v;
-                }
-            }
-        }
-    }
+			$findRx = "~{$findRxWhole}~iu"; // Case-insensitive and UTF-8 mode
 
-    if (empty($tmp)) {
-        return false;
-    }
+			$lines = file($filepath);
 
-    return $tmp = get_posts($tmp, $page, $perpage);
+			foreach ($lines as $line) {
+				if (preg_match ($findRx, $line)) {
+					if (!in_array($v, $tmp)) {
+                    	$tmp[] = $v;
+					}
+            	}
+			}
+    	}
 
+    	if (empty($tmp)) {
+        	return false;
+    		}
+
+    	return $tmp = get_posts($tmp, $page, $perpage);
+
+	}
 }
 
 // Get related posts base on post category.
@@ -1513,32 +1517,35 @@ function get_tagcount($var)
 // Return search result count
 function keyword_count($keyword)
 {
-    $posts = get_blog_posts();
 
-    $tmp = array();
+	if (strlen($keyword) >= 3) {    
 
-    foreach ($posts as $index => $v) {
+		$posts = get_blog_posts();
 
-		$filepath = $v['dirname'] . '/' . $v['basename'];
+		$tmp = array();
 
-		$findRxWhole = '\b' . preg_quote($keyword, '~') . '\b'; // Add word boundaries (find whole-words only)
+		foreach ($posts as $index => $v) {
 
-		$findRx = "~{$findRxWhole}~iu"; // Case-insensitive and UTF-8 mode
+			$filepath = $v['dirname'] . '/' . $v['basename'];
 
-		$lines = file($filepath);
+			$findRxWhole = '\b' . preg_quote($keyword, '~') . '\b'; // Add word boundaries (find whole-words only)
 
-		foreach ($lines as $line) {
-			if (preg_match ($findRx, $line)) {
-				if (!in_array($v, $tmp)) {
+			$findRx = "~{$findRxWhole}~iu"; // Case-insensitive and UTF-8 mode
+
+			$lines = file($filepath);
+
+			foreach ($lines as $line) {
+				if (preg_match ($findRx, $line)) {
+					if (!in_array($v, $tmp)) {
 					$tmp[] = $v;
-            	}
-        	}
-    	}
-    }
+            		}
+        		}
+    		}
+		}
 
-    $tmp = array_unique($tmp, SORT_REGULAR);
-
-    return count($tmp);
+    	$tmp = array_unique($tmp, SORT_REGULAR);
+    	return count($tmp);
+	}
 }
 
 // Return recent posts lists

--- a/themes/doks/main.html.php
+++ b/themes/doks/main.html.php
@@ -31,7 +31,7 @@
 <!-- main.html.php -->
 <div class="row justify-content-center" style="padding-top: 3rem;">
     <div class="col-md-12 text-center">
-        <h2 class="mt-0">Search: <span style='color: #628B48;'><?php echo $search->title;?></span> (<?php echo $search->count;?>)</h2>
+        <h1 class="mt-0">Search: <span style='color: #628B48;'><?php echo $search->title;?></span> (<?php echo $search->count;?>)</h1>
         <form><input type="search" name="search" class="form-control is-search" placeholder="<?php echo i18n('Type_to_search');?>"></form>
     </div>
 </div>


### PR DESCRIPTION
Noticed after-the-fact that the Search $keyword had no character limits, so added a qualification to Search for ≥ three-character strings.

Additional cleanup included.

*pardon the amateur messiness*