### PR TITLE
update htmly.php -> display categories on /category page; see #864

### DIFF
--- a/system/htmly.php
+++ b/system/htmly.php
@@ -3045,6 +3045,58 @@ get('/category/:category', function ($category) {
     ), $layout);
 });
 
+// Show categories with descriptions on /category page 
+get('/category', function () {
+
+    if (!login()) {
+        file_cache($_SERVER['REQUEST_URI']);
+    }
+
+    $categories = get_category_info();
+
+	$categoriesData = array(
+		'title' => generate_title('is_default', i18n('Categories')),
+		'description' => i18n('Categories').' '.i18n('of').' '.safe_html(strip_tags(blog_tagline())),
+		'metatags' => generate_meta(null, null),
+		'canonical' => site_url() . 'category',
+		'is_categories' => true
+	);
+
+    $vroot = rtrim(config('views.root'), '/');
+    
+    $lt = $vroot . '/layout--categories.html.php'; 
+    if (file_exists($lt)) {
+        $layout = 'layout--categories';
+    } else {
+        $layout = '';
+    }
+    
+    $pv = $vroot . '/main--categories.html.php';
+	if (file_exists($pv)) {
+        $pview = 'main--categories';
+		$categoriesData['categories'] = $categories;
+    } else {
+        $pview = 'main';
+		$categoriesData['posts'] = $categories;
+		//fallback for custom themes lacking main--categories.html.php
+		foreach ($categories as $category) {
+			$category->category = i18n('Categories');
+			$category->tag = NULL;
+			$category->readTime = "0";
+			$category->authorName = "Admin";
+			if (!empty(config('default.image'))) {
+				$category->authorAvatar = config('default.image');
+			} else $category->authorAvatar = NULL;
+			$category->authorUrl = '#';
+			if (file_exists($category->file)) {
+				$category->date = filemtime($category->file) ;
+			} else $category->date = NULL;
+		}		
+    }
+
+	render($pview, $categoriesData);
+});
+
 // Show the RSS feed
 get('/category/:category/feed', function ($category) {
 

--- a/themes/blog/main--categories.html.php
+++ b/themes/blog/main--categories.html.php
@@ -1,0 +1,18 @@
+<?php if (!defined('HTMLY')) die('HTMLy'); ?>
+<article class="type-post hentry section">
+	<header class="entry-header">
+		<h1 class="entry-title"><?php echo i18n('Categories');?></h1>
+	</header>
+	<div class="entry-content section-inner">
+	<?php foreach ($categories as $category): ?>
+		<div class="category-item post type-post">
+			<?php if ($category->count > 0): ?>
+			<h2><a href="<?php echo $category->url; ?>"><?php echo $category->title; ?></a></h2>
+			<?php else: ?>
+			<h2><?php echo $category->title; ?></h2>
+			<?php endif; ?>
+			<p><?php echo $category->description; ?></p>
+		</div>
+	<?php endforeach; ?>
+	</div>
+</article>

--- a/themes/clean/main--categories.html.php
+++ b/themes/clean/main--categories.html.php
@@ -1,0 +1,18 @@
+<?php if (!defined('HTMLY')) die('HTMLy'); ?>
+<article class="type-post hentry section">
+	<header class="entry-header">
+		<h1 class="entry-title"><?php echo i18n('Categories');?></h1>
+	</header>
+	<div class="entry-content section-inner">
+	<?php foreach ($categories as $category): ?>
+		<div class="category-item post type-post">
+			<?php if ($category->count > 0): ?>
+			<h2><a href="<?php echo $category->url; ?>"><?php echo $category->title; ?></a></h2>
+			<?php else: ?>
+			<h2><?php echo $category->title; ?></h2>
+			<?php endif; ?>
+			<p><?php echo $category->description; ?></p>
+		</div>
+	<?php endforeach; ?>
+	</div>
+</article>

--- a/themes/doks/main--categories.html.php
+++ b/themes/doks/main--categories.html.php
@@ -1,0 +1,18 @@
+<?php if (!defined('HTMLY')) die('HTMLy'); ?>
+<article class="type-post hentry section">
+	<header class="entry-header">
+		<h1 class="entry-title"><?php echo i18n('Categories');?></h1>
+	</header>
+	<div class="entry-content section-inner">
+	<?php foreach ($categories as $category): ?>
+		<div class="category-item post type-post">
+			<?php if ($category->count > 0): ?>
+			<h2><a href="<?php echo $category->url; ?>"><?php echo $category->title; ?></a></h2>
+			<?php else: ?>
+			<h2><?php echo $category->title; ?></h2>
+			<?php endif; ?>
+			<p><?php echo $category->description; ?></p>
+		</div>
+	<?php endforeach; ?>
+	</div>
+</article>

--- a/themes/logs/main--categories.html.php
+++ b/themes/logs/main--categories.html.php
@@ -1,0 +1,18 @@
+<?php if (!defined('HTMLY')) die('HTMLy'); ?>
+<article class="type-post hentry section">
+	<header class="entry-header">
+		<h1 class="entry-title"><?php echo i18n('Categories');?></h1>
+	</header>
+	<div class="entry-content section-inner">
+	<?php foreach ($categories as $category): ?>
+		<div class="category-item post type-post">
+			<?php if ($category->count > 0): ?>
+			<h2><a href="<?php echo $category->url; ?>"><?php echo $category->title; ?></a></h2>
+			<?php else: ?>
+			<h2><?php echo $category->title; ?></h2>
+			<?php endif; ?>
+			<p><?php echo $category->description; ?></p>
+		</div>
+	<?php endforeach; ?>
+	</div>
+</article>

--- a/themes/readable/main--categories.html.php
+++ b/themes/readable/main--categories.html.php
@@ -1,0 +1,18 @@
+<?php if (!defined('HTMLY')) die('HTMLy'); ?>
+<article class="type-post hentry section">
+	<header class="entry-header">
+		<h1 class="entry-title"><?php echo i18n('Categories');?></h1>
+	</header>
+	<div class="entry-content section-inner">
+	<?php foreach ($categories as $category): ?>
+		<div class="category-item post type-post">
+			<?php if ($category->count > 0): ?>
+			<h2><a href="<?php echo $category->url; ?>"><?php echo $category->title; ?></a></h2>
+			<?php else: ?>
+			<h2><?php echo $category->title; ?></h2>
+			<?php endif; ?>
+			<p><?php echo $category->description; ?></p>
+		</div>
+	<?php endforeach; ?>
+	</div>
+</article>

--- a/themes/twentyfifteen/main--categories.html.php
+++ b/themes/twentyfifteen/main--categories.html.php
@@ -1,0 +1,18 @@
+<?php if (!defined('HTMLY')) die('HTMLy'); ?>
+<article class="type-post hentry section">
+	<header class="entry-header">
+		<h1 class="entry-title"><?php echo i18n('Categories');?></h1>
+	</header>
+	<div class="entry-content section-inner">
+	<?php foreach ($categories as $category): ?>
+		<div class="category-item post type-post">
+			<?php if ($category->count > 0): ?>
+			<h2><a href="<?php echo $category->url; ?>"><?php echo $category->title; ?></a></h2>
+			<?php else: ?>
+			<h2><?php echo $category->title; ?></h2>
+			<?php endif; ?>
+			<p><?php echo $category->description; ?></p>
+		</div>
+	<?php endforeach; ?>
+	</div>
+</article>

--- a/themes/twentysixteen/main--categories.html.php
+++ b/themes/twentysixteen/main--categories.html.php
@@ -1,0 +1,18 @@
+<?php if (!defined('HTMLY')) die('HTMLy'); ?>
+<article class="type-post hentry section">
+	<header class="entry-header">
+		<h1 class="entry-title"><?php echo i18n('Categories');?></h1>
+	</header>
+	<div class="entry-content section-inner">
+	<?php foreach ($categories as $category): ?>
+		<div class="category-item post type-post">
+			<?php if ($category->count > 0): ?>
+			<h2><a href="<?php echo $category->url; ?>"><?php echo $category->title; ?></a></h2>
+			<?php else: ?>
+			<h2><?php echo $category->title; ?></h2>
+			<?php endif; ?>
+			<p><?php echo $category->description; ?></p>
+		</div>
+	<?php endforeach; ?>
+	</div>
+</article>


### PR DESCRIPTION
Changes made to show categories with their descriptions on /category URI; thread #864 
Additional main--categories.html.php file for themes (except tailwind), although not needed as categories will be gracefully listed in a manner of posts. This is also a fallback for custom themes that lacks this file, assuming loops for displaying posts in main.html.php were not customized.