### PR TITLE
Refactor autosave draft script and add error handling

### DIFF
--- a/system/admin/editor/css/editor.css
+++ b/system/admin/editor/css/editor.css
@@ -182,3 +182,7 @@ pre code {
     align-items: center;
     display: none;
 }
+
+.notice.error {
+  background-color: #fdd;
+}

--- a/system/admin/views/edit-content.html.php
+++ b/system/admin/views/edit-content.html.php
@@ -145,6 +145,7 @@ $( function() {
 <?php if (isset($error)) { ?>
     <div class="error-message"><?php echo $error ?></div>
 <?php } ?>
+<div class="notice error" id="response-error"></div>
 <div class="notice" id="response"></div>
 <div class="row">
     <div class="hide-button" style="margin-bottom:1em;width:100%;text-align:right;"><button type="button" title="<?php echo i18n('Focus_mode');?>" id="hideButton" class="note-btn btn btn-sm <?php echo ((config('admin.theme') === 'light' || is_null(config('admin.theme'))) ? "btn-light" : "btn-dark");?>" style="width:38px;height:38px;font-size:18px;" ><i class="fa fa-eye" aria-hidden="true"></i></button></div>

--- a/system/resources/js/save_draft.js
+++ b/system/resources/js/save_draft.js
@@ -1,43 +1,29 @@
-const response = document.getElementById("response");
+function hideError() {
+  $("#response-error").fadeOut(600, function() {
+    $("#response-error").css("display", "none");
+  });
+}
 
 function updateData() {
-  var title = $("#pTitle").val();
-  var url = $("#pURL").val();
-  var content = $("#wmd-input").val();
-  var description = $("#pMeta").val();
-  var tag = $("#pTag").val();
-  var category = $("#pCategory").val();
-  var posttype = $("#pType").val();
-  var pimage = $("#pImage").val();
-  var paudio = $("#pAudio").val();
-  var pvideo = $("#pVideo").val();
-  var pquote = $("#pQuote").val();
-  var plink = $("#pLink").val();
-  var pDate = $("#pDate").val();
-  var pTime = $("#pTime").val();
-  var oldfile = $("#oldfile").val();
-  var dateTime = pDate + " " + pTime;
-  var autoSave = 'autoSave';
-
   // Prepare data to send to PHP
   var data = {
-    title: title,
-    url: url,
-    content: content,
-    description: description,
-    tag: tag,
-    category: category,
-    posttype: posttype,
-    pimage: pimage,
-    paudio: paudio,
-    pvideo: pvideo,
-    pquote: pquote,
-    plink: plink,
-    dateTime: dateTime,
-    autoSave: autoSave,
+    title: $("#pTitle").val(),
+    url: $("#pURL").val(),
+    content: $("#wmd-input").val(),
+    description: $("#pMeta").val(),
+    tag: $("#pTag").val(),
+    category: $("#pCategory").val(),
+    posttype: $("#pType").val(),
+    pimage: $("#pImage").val(),
+    paudio: $("#pAudio").val(),
+    pvideo: $("#pVideo").val(),
+    pquote: $("#pQuote").val(),
+    plink: $("#pLink").val(),
+    dateTime: $("#pDate").val() + " " + $("#pTime").val(),
+    autoSave: 'autoSave',
     addEdit: addEdit,
-    oldfile: oldfile,
-	parent_page: parent_page
+    oldfile: $("#oldfile").val(),
+    parent_page: parent_page
   };
   
   $.ajax({
@@ -47,6 +33,7 @@ function updateData() {
     success: function(response) {
       $("#response").html(response.message);
       $("#oldfile").val(response.file);
+      hideError();
       $("#response").fadeIn(600, function() {
         $("#response").css("display", "block");
       });
@@ -55,6 +42,13 @@ function updateData() {
           $("#response").css("display", "none");
         });
       }, 6000);
+    },
+    error: function(response) {
+      $("#response-error").html("Error in Autosaving: " + response.statusText);
+      $("#response-error").fadeIn(600, function() {
+        $("#response-error").css("display", "block");
+      });
+      setTimeout(hideError, saveInterval/2);
     }
   });
 }


### PR DESCRIPTION
Hello once again,
While editing on HTMLy, I noticed a problem with the draft autosaving feature: if, for any reason, the autosave task fails, there's no obvious way to tell. When it succeeds, a notification is shown on-screen, but that's not the case for fails.
The consequences of this can range from mildly inconvenient if the Internet connection to the server drops, to outright catastrophic (ask me how I know) if the cause of autosave failing is the session expiring, because closing or reloading the window will lead to losing the last X minutes of work.

While we should probably consider implementing some kind of a buffer for autosaving, maybe using localStorage, something small can be done even just now to mitigate this issue, and this is what this PR does.
I added an error handling function to the AJAX call used by the client-side script to automatically save drafts, to ensure that an error notice (in a different color, a red with similar brightness to the blue used for success notices) is shown when, for any reason, the request fails. The notice persists for enough time on screen that the user can see if something has gone wrong, going away either after half the autosave time or when a successful autosave happens (in case of temporary failure).
I also took the opportunity to generally refactor the script, since it had accumulated a lot of useless variables.