### PR TITLE
Add fullscreen feature to Markdown editor

### DIFF
--- a/system/admin/editor/css/editor.css
+++ b/system/admin/editor/css/editor.css
@@ -132,6 +132,36 @@ blockquote {
     font-weight: bold;
 }
 
+#wmd-maximize-button, #wmd-minimize-button {
+    float: right;
+}
+
+div.fullscreen-editor {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+div.fullscreen-editor > textarea {
+    flex: 1;
+    margin-bottom: 10px;
+}
+
+div.fullscreen-wrapper > div#preview-col,
+div.fullscreen-editor > a,
+div.fullscreen-editor > br,
+div.fullscreen-editor > details,
+div.fullscreen-editor > label,
+div.fullscreen-editor > input[type="submit"] {
+    display: none;
+}
+
 pre {
     margin: 1em 0;
     overflow: auto;

--- a/system/admin/editor/js/Markdown.Editor.js
+++ b/system/admin/editor/js/Markdown.Editor.js
@@ -56,6 +56,9 @@
 		
         table: "Table - Ctrl+J",
 
+        maximize: "Maximize CTRL+P",
+        minimize: "Minimize CTRL+P",
+
         undo: "Undo - Ctrl+Z",
         redo: "Redo - Ctrl+Y",
         redomac: "Redo - Ctrl+Shift+Z",
@@ -1317,6 +1320,9 @@
                     case "j":
                         doClick(buttons.table);
                         break;
+                    case "p":
+                        doClick(buttons.maximize);
+                        break;
                     // case "y":
                     //     doClick(buttons.redo);
                     //     break;
@@ -1523,6 +1529,11 @@
             buttons.hr = makeButton("wmd-hr-button", getString("hr"), "fa fa-ellipsis-h", bindCommand("doHorizontalRule"));
             buttons.readmore = makeButton("wmd-readmore-button", getString("readmore"), "fa fa-arrow-right", bindCommand("doReadMore"));
             buttons.toc = makeButton("wmd-toc-button", getString("toc"), "fa fa-list-alt", bindCommand("doTOC"));
+
+            buttons.maximize = makeButton("wmd-maximize-button", getString("maximize"), "fa-solid fa-maximize", toggleFullscreen);
+            buttons.minimize = makeButton("wmd-minimize-button", getString("minimize"), "fa-solid fa-minimize", toggleFullscreen);
+            buttons.minimize.hidden = true;
+
             //makeSpacer(3);
             buttons.undo = makeButton("wmd-undo-button", getString("undo"), "fa-solid fa-rotate-left", null);
             buttons.undo.execute = function (manager) {
@@ -1556,6 +1567,20 @@
             }
 
             setUndoRedoButtonStates();
+        }
+
+        function toggleFullscreen() {
+            var parent = panels.input.parentElement;
+            if (!parent.style.backgroundColor) {
+                parent.style.backgroundColor = getComputedStyle(document.body).backgroundColor;
+            }
+            var fullscreen = parent.classList.toggle('fullscreen-editor');
+            parent.parentElement.parentElement.classList.toggle('fullscreen-wrapper', fullscreen);
+            buttons.maximize.hidden = fullscreen;
+            buttons.minimize.hidden = !fullscreen;
+            document.body.style.overflowY = fullscreen ? 'hidden' : null;
+            document.body.querySelector('aside.main-sidebar').style.display =
+            document.body.querySelector('nav.main-header').style.display = fullscreen ? 'none' : null;
         }
 
         function setUndoRedoButtonStates() {
@@ -2487,5 +2512,11 @@
 	  }
     };
 
+    // better fullscreen editing on mobile by letting the browser resize viewport when keyboard is open
+    var metaViewport = document.querySelector("meta[name=viewport]");
+    var mobileFix = 'interactive-widget=resizes-content';
+    if (!metaViewport.content.split(',').includes(mobileFix)) {
+        metaViewport.content += ',' + mobileFix;
+    }
 
 })();


### PR DESCRIPTION
Since I started to use HTMLy, the Markdown editor has always felt kind of strange to me for long posts. After a bit of reflecting, I noticed that this is because any other normal text or blog editor (Notepad, Word, WordPress, even specialized Markdown editors) don't often have the quirks of a form-based webpage, where you have the textarea that holds the main content that is just a little element on a scrolling page with many other elements, which instead HTMLy does.

This is uncomfortable in general, because the scrolling of the page in general tends to hide formatting buttons from view when writing, or even cause double scrolling when the textarea is shorter than the text contained (and the textarea in HTMLy does not resize to grow or shrink based on the content, so double scrolling always happens). On mobile, where screen space is little and browsers cause even more layout shifts when the virtual keyboard is opened or closed, this is an even bigger issue.

This commit, then, adds a small improvement to the existing Markdown editor, which otherwise continues working as usual, in the form of a toggleable fullscreen view, which can be activated or deactivated by pressing CTRL+P or the dedicated button in the editor toolbar. When deactivated (default), as said, the editor continues working as usual. When activated, using some CSS transformations, the editor area is placed in a way to cover the entire page viewport, showing the editor toolbar at the top, and the textarea below, set to take all remaining available space. Screenshots attached for demonstration; tested on both Firefox and Chromium on desktop, and Chromium on Android.

<table><tr><td><img src="https://github.com/user-attachments/assets/0e3cff37-e96b-4fc4-9d91-906cf6b9be28" /></td><td><img width="1360" height="768" src="https://github.com/user-attachments/assets/3911c781-b34e-47cb-93ce-0293c87ddc8b" /></td></tr></table>

Additionally, with some extra JavaScript that dynamically inserts a special meta viewport value, as illustrated in <https://developer.chrome.com/blog/viewport-resize-behavior>, when using the editor in this new fullscreen mode on mobile the viewport is resized automatically to account for the virtual keyboard, keeping the textarea always fully visible and preventing the double scrolling discussed above. In short, I think this addition can improve the editing experience for anyone.